### PR TITLE
Updated Cloudformation templates to use latest Python version

### DIFF
--- a/create-file-system/templates/efs-dashboard-with-size-monitor-and-burst-credit-balance-alarms.yml
+++ b/create-file-system/templates/efs-dashboard-with-size-monitor-and-burst-credit-balance-alarms.yml
@@ -315,7 +315,7 @@ Resources:
       FunctionName: !Join [ '', [ 'efs-', !Ref ElasticFileSystem, '-size-monitor' ] ]
       Handler: index.handler
       Role: !GetAtt LambdaRoleRetain.Arn
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 60
   EfsSizeMonitorFunctionDelete:
     Type: AWS::Lambda::Function
@@ -376,7 +376,7 @@ Resources:
       FunctionName: !Join [ '', [ 'efs-', !Ref ElasticFileSystem, '-size-monitor' ] ]
       Handler: index.handler
       Role: !GetAtt LambdaRoleDelete.Arn
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 60
   LambdaRoleRetain:
     Type: AWS::IAM::Role

--- a/create-file-system/templates/efs-dashboard-with-size-monitor.yml
+++ b/create-file-system/templates/efs-dashboard-with-size-monitor.yml
@@ -159,7 +159,7 @@ Resources:
       FunctionName: !Join [ '', [ 'efs-', !Ref ElasticFileSystem, '-size-monitor' ] ]
       Handler: index.handler
       Role: !GetAtt LambdaRoleRetain.Arn
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 60
   EfsSizeMonitorFunctionDelete:
     Type: AWS::Lambda::Function
@@ -220,7 +220,7 @@ Resources:
       FunctionName: !Join [ '', [ 'efs-', !Ref ElasticFileSystem, '-size-monitor' ] ]
       Handler: index.handler
       Role: !GetAtt LambdaRoleDelete.Arn
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 60
   LambdaRoleRetain:
     Type: AWS::IAM::Role

--- a/monitoring/templates/cw_dashboard_with_mm_for_efs.yaml
+++ b/monitoring/templates/cw_dashboard_with_mm_for_efs.yaml
@@ -520,7 +520,7 @@ Resources:
       FunctionName: !Join [ '-', [ !Ref ElasticFileSystem, 'size-monitor', !Ref 'AWS::StackName' ] ]
       Handler: index.handler
       Role: !GetAtt LambdaRoleRetain.Arn
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 60
 
   EfsSizeMonitorFunctionDelete:
@@ -582,7 +582,7 @@ Resources:
       FunctionName: !Join [ '-', [ !Ref ElasticFileSystem, 'size-monitor', !Ref 'AWS::StackName' ] ]
       Handler: index.handler
       Role: !GetAtt LambdaRoleDelete.Arn
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 60
 
   LambdaRoleRetain:

--- a/monitoring/templates/efs-dashboard-with-size-monitor-and-burst-credit-balance-alarms.yml
+++ b/monitoring/templates/efs-dashboard-with-size-monitor-and-burst-credit-balance-alarms.yml
@@ -315,7 +315,7 @@ Resources:
       FunctionName: !Join [ '', [ 'efs-', !Ref ElasticFileSystem, '-size-monitor' ] ]
       Handler: index.handler
       Role: !GetAtt LambdaRoleRetain.Arn
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 60
   EfsSizeMonitorFunctionDelete:
     Type: AWS::Lambda::Function
@@ -376,7 +376,7 @@ Resources:
       FunctionName: !Join [ '', [ 'efs-', !Ref ElasticFileSystem, '-size-monitor' ] ]
       Handler: index.handler
       Role: !GetAtt LambdaRoleDelete.Arn
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 60
   LambdaRoleRetain:
     Type: AWS::IAM::Role

--- a/monitoring/templates/efs-dashboard-with-size-monitor.yml
+++ b/monitoring/templates/efs-dashboard-with-size-monitor.yml
@@ -159,7 +159,7 @@ Resources:
       FunctionName: !Join [ '', [ 'efs-', !Ref ElasticFileSystem, '-size-monitor' ] ]
       Handler: index.handler
       Role: !GetAtt LambdaRoleRetain.Arn
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 60
   EfsSizeMonitorFunctionDelete:
     Type: AWS::Lambda::Function
@@ -220,7 +220,7 @@ Resources:
       FunctionName: !Join [ '', [ 'efs-', !Ref ElasticFileSystem, '-size-monitor' ] ]
       Handler: index.handler
       Role: !GetAtt LambdaRoleDelete.Arn
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 60
   LambdaRoleRetain:
     Type: AWS::IAM::Role


### PR DESCRIPTION
*Issue #:* N/A

*Description of changes:*

https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html

Runtime support document is out of date, but Python 2.7 will become end of support on 1st January 2020 and then end of life for lambda at the end of the year.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
