### PR TITLE
replaces all versions of nodejs to 10.x 

### DIFF
--- a/in-cloud-transfer/templates/datasync_in-cloud_transfer_quick_start_scheduler.yaml
+++ b/in-cloud-transfer/templates/datasync_in-cloud_transfer_quick_start_scheduler.yaml
@@ -136,7 +136,7 @@ Resources:
         S3Bucket: !Sub solution-references-${AWS::Region}
         S3Key: datasync/amilookup-datasync-agent.zip
       Handler: amilookup-datasync-agent.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 30
       Role: !GetAtt LambdaExecutionRole.Arn
   AmiInfo:


### PR DESCRIPTION
Because nodejs8.10 is no longer a supported runtime

Resolves #11 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
