### PR TITLE
Remove outdated allowedPattern for EFSFileSystemId

### DIFF
--- a/in-cloud-transfer/templates/datasync_in-cloud_transfer_quick_start_scheduler.yaml
+++ b/in-cloud-transfer/templates/datasync_in-cloud_transfer_quick_start_scheduler.yaml
@@ -67,7 +67,6 @@ Metadata:
         default: Schedule of task run
 Parameters:
   DestinationEfsFilesystemId:
-    AllowedPattern: ^(fs-)([a-z0-9]{8})$
     Description: Destination EFS filesystem id.
     Type: String
   DestinationLocationRegion:


### PR DESCRIPTION
*Issue #, if available:*

My FileSystemId contained much more than 8 characters. Due to this, the template would not commit and gave me an error message. I suppose, that AWS has changed their EFS id system and that this template has not been updated since. If that assumption is true, this PR would fix it. Admittedly, in a rather lazy way, as I didn't bother to figure out what the new rule should look like. I leave that up to the maintainer.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
